### PR TITLE
feat: use metadata prop Bundle-SymbolicName as artifact id.

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
-      - uses: SonarSource/sonarqube-scan-action@v1.1.0
+      - uses: SonarSource/sonarqube-scan-action@v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 17
       - uses: SonarSource/sonarqube-scan-action@v1.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -11,9 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 17
+          java-version: '17'
+          distribution: 'adopt'
       - uses: SonarSource/sonarqube-scan-action@v1.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/lib/client/ManifestReader.ts
+++ b/src/lib/client/ManifestReader.ts
@@ -33,8 +33,8 @@ export default class ManifestReader {
     getArtifactMetadata(): Artifact {
         return {
             Id:
-                (this.manifestEntries.get('Origin-Bundle-SymbolicName') as string) ||
-                (this.manifestEntries.get('Bundle-SymbolicName') as string).split(';')[0],
+                (this.manifestEntries.get('Bundle-SymbolicName') as string).split(';')[0] ||
+                (this.manifestEntries.get('Origin-Bundle-SymbolicName') as string),
             Version: this.manifestEntries.get('Bundle-Version') as string,
             Name: this.manifestEntries.get('Bundle-Name') as string,
             Type: this.manifestEntries.get('SAP-BundleType') as ArtifactType,

--- a/src/test/Testpackage/com.sap.SFIHCM03.hcm2bizx.SFSFOffboardingGetOffboardUserRecordWithExpabcd.EBZ/META-INF/MANIFEST.MF
+++ b/src/test/Testpackage/com.sap.SFIHCM03.hcm2bizx.SFSFOffboardingGetOffboardUserRecordWithExpabcd.EBZ/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Description: 
 Bundle-SymbolicName: com.sap.SFIHCM03.hcm2bizx.SFSFOffboardingGetOffbo
- ardUserRecordWithExpabcd; singleton:=true
+ ardUserRecordWithExpabcd.EBZ; singleton:=true
 Origin-Bundle-SymbolicName: com.sap.SFIHCM03.hcm2bizx.SFSFOffboardingG
  etOffboardUserRecordWithExpabcd
 Bundle-ManifestVersion: 2

--- a/src/test/integration/IntegrationFlow.test.ts
+++ b/src/test/integration/IntegrationFlow.test.ts
@@ -32,7 +32,7 @@ describe('Integration flow', () => {
         });
 
         it('fetch an integration flow ', async () => {
-            const iFlowId = sciRestClient.getArtifactMetadata(path.join(artiFactDirectory, 'TestPackage', iFlowFolder)).Id;
+            const iFlowId = sciRestClient.getArtifactMetadata(path.join(artiFactDirectory, 'Testpackage', iFlowFolder)).Id;
             const readStream = (await sciRestClient.getArtifact(iFlowId, '1.0.0', 'IntegrationFlow')) as ReadStream;
 
             const writer = fs.createWriteStream(path.join(artiFactDirectory, 'test.zip'));


### PR DESCRIPTION
Use metadata prop Bundle-SymbolicName as artifact id. Origin-Bundle-SymbolicName will be used as fallback since it turned out that the latter one did not match the folder name of the Artifact in all cases